### PR TITLE
Add basic site description to home page

### DIFF
--- a/app/views/index.html.erb
+++ b/app/views/index.html.erb
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Jessica Bohn</title>
+
+</head>
+<body>
+
+  <div class="under-construction">
+    <p>
+      Site curretnly under construction
+    </p>
+  </div>
+
+  <div class="general-description">
+    <p>Hello there! I am Jessica Bohn and this page is meant to showcase my web development
+      projects and newly acquired skills in the field
+    </p>
+  </div>


### PR DESCRIPTION
The current home page had nothing on it and would therefore default
to the Rails app sample page, which is not very welcoming or
explanatory for visitors. So I added a simple description to the main
index page along with a note that the site is under construction so
that visitors do not automatically think that my site/code is broken.